### PR TITLE
Aewb logger

### DIFF
--- a/aewb_logger/aewb_logger_receiver.h
+++ b/aewb_logger/aewb_logger_receiver.h
@@ -5,6 +5,7 @@
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include "linux_aewb_handle_type.h"
 #include "aewb_logger_types.h"
 #include "aewb_logger_receiver_types.h"
 

--- a/aewb_logger/aewb_logger_sender.h
+++ b/aewb_logger/aewb_logger_sender.h
@@ -6,6 +6,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include "linux_aewb_module.h"
+#include "linux_aewb_handle_type.h"
 #include "aewb_logger_types.h"
 #include "aewb_logger_sender_types.h"
 

--- a/aewb_logger/aewb_logger_test.c
+++ b/aewb_logger/aewb_logger_test.c
@@ -7,7 +7,7 @@
 
 void test_create_failure() {
     aewb_logger_sender_state_t *sender = aewb_logger_create_sender("333.444.555.666", 4321); // pass illegal ip
-    aewb_logger_sender_state_t *receiver = aewb_logger_create_receiver("333.444.555.666", 4321); // pass illegal ip
+    aewb_logger_receiver_state_t *receiver = aewb_logger_create_receiver("333.444.555.666", 4321); // pass illegal ip
     assert (sender == NULL);
     assert (receiver == NULL);
 }

--- a/modules/include/linux_aewb_handle_type.h
+++ b/modules/include/linux_aewb_handle_type.h
@@ -1,0 +1,31 @@
+/*
+    this _AewbHandle definition used to be in linux_aewb_module.c
+    it was moved to this new file so that aewb_logger_* files could include it
+    it was moved to this file and not to linux_aewb_module.h to avoid changing the linux_aewb_module.h interface
+*/
+#ifndef _LINUX_AEWB_HANDLE_TYPE_H
+#define _LINUX_AEWB_HANDLE_TYPE_H
+
+#include "linux_aewb_module.h"
+#include "tiovx_utils.h"
+#include "ti_2a_wrapper.h"
+#include "aewb_logger_sender_types.h"
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+struct _AewbHandle {
+    AewbCfg             cfg;
+    tivx_aewb_config_t  aewb_config;
+    SensorObj           sensor_obj;
+    uint8_t             *dcc_2a_buf;
+    uint32_t            dcc_2a_buf_size;
+    TI_2A_wrapper       ti_2a_wrapper;
+    sensor_config_get   sensor_in_data;
+    sensor_config_set   sensor_out_data;
+    int fd;
+    aewb_logger_sender_state_t *aewb_logger_sender_state_ptr;
+};
+
+#endif //_LINUX_AEWB_HANDLE_TYPE_H

--- a/modules/include/linux_aewb_module.h
+++ b/modules/include/linux_aewb_module.h
@@ -63,11 +63,8 @@
 #ifndef _AEWB_MODULE
 #define _AEWB_MODULE
 
-#include "ti_2a_wrapper.h"
 #include "tiovx_modules_types.h"
 #include <tiovx_sensor_module.h>
-#include <aewb_logger_sender_types.h>
-#include <TI/j7_kernels_imaging_aewb.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,19 +95,6 @@ typedef struct {
     /*! \brief Sensor name as defined in Imaging repo */
     vx_char     sensor_name[ISS_SENSORS_MAX_NAME];
 } AewbCfg;
-
-struct _AewbHandle {
-    AewbCfg             cfg;
-    tivx_aewb_config_t  aewb_config;
-    SensorObj           sensor_obj;
-    uint8_t             *dcc_2a_buf;
-    uint32_t            dcc_2a_buf_size;
-    TI_2A_wrapper       ti_2a_wrapper;
-    sensor_config_get   sensor_in_data;
-    sensor_config_set   sensor_out_data;
-    int fd;
-    aewb_logger_sender_state_t *aewb_logger_sender_state_ptr;
-};
 
 typedef struct _AewbHandle AewbHandle;
 

--- a/modules/src/linux_aewb_module.c
+++ b/modules/src/linux_aewb_module.c
@@ -60,10 +60,11 @@
  *
  */
 
+#include "linux_aewb_module.h"
 #include "tiovx_utils.h"
 #include "ti_2a_wrapper.h"
-#include "linux_aewb_module.h"
 #include "aewb_logger_sender.h"
+#include "linux_aewb_handle_type.h"
 
 #include <sys/ioctl.h>
 #include <errno.h>


### PR DESCRIPTION
originally `_AewbHandle` was moved from `linux_aewb_module.c` to `linux_aewb_module.h`
this wasn't very elegant -
* it changed the `linux_aewb_module.h`
* it introduced `_AewbHandle` to a bigger scope than necessary
* it added includes to `linux_aewb_module.h` which would then propagate to other files

this change moved `_AewbHandle` to a new h file, which is slightly better.