### PR TITLE
fixed make install error

### DIFF
--- a/aewb_logger/CMakeLists.txt
+++ b/aewb_logger/CMakeLists.txt
@@ -19,5 +19,5 @@ set(TEST_SRC_FILES
     aewb_logger_test.c
     )
 
-build_app(aewb_logger_test
+build_app_no_install(aewb_logger_test
           ${TEST_SRC_FILES})

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -186,6 +186,19 @@ function(build_app app_name)
 
 endfunction()
 
+function(build_app_no_install app_name)
+    add_executable(${app_name} ${ARGN})
+    target_link_libraries(${app_name}
+                          ${COMMON_LINK_LIBS}
+                          ${TARGET_LINK_LIBS}
+                          ${SYSTEM_LINK_LIBS}
+                         )
+
+    set(BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
+    set(BINS ${CMAKE_OUTPUT_DIR}/bin/${CMAKE_BUILD_TYPE}/${app_name})
+endfunction()
+
+
 # Function for building a node:
 # lib_name: Name of the library
 # lib_type: (STATIC, SHARED)


### PR DESCRIPTION
the pr fixes the following error
```
make install DESTDIR=/tmp -C build

Install the project...
-- Install configuration: ""
-- Installing: /home/ansible_client/workspace/TI-Artifacts-do-not-delete/ti-firmware-builder-am62axx-evm-09_02_00_05/targetfs/usr/lib/libaewb_logger.so.0.1.0
-- Installing: /home/ansible_client/workspace/TI-Artifacts-do-not-delete/ti-firmware-builder-am62axx-evm-09_02_00_05/targetfs/usr/lib/libaewb_logger.so
CMake Error at aewb_logger/cmake_install.cmake:102 (file):
  file INSTALL cannot find
  "/home/ansible_client/workspace/TI-Artifacts-do-not-delete/ti-firmware-builder-am62axx-evm-09_02_00_05/edgeai/edgeai-tiovx-apps/bin/Debug/aewb_logger_test":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:47 (include)
```

short story - 
we don't need to install the debug app in /usr/bin/, the only reason the debug app had an install directive was that it was using a common.cmake generic function that included an install directive.
i simply added a different variant of the function with install().

long story- 
edgeai-tiovx-apps has a common.cmake which is included in the aewb_logger cmake.
it sets the output dir to release because `CMAKE_BUILD_TYPE` is release at that point of the cmake.
```
set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIR}/lib/${CMAKE_BUILD_TYPE})
set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIR}/lib/${CMAKE_BUILD_TYPE})
set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIR}/bin/${CMAKE_BUILD_TYPE})
```
but then we define test application and change CMAKE_BUILD_TYPE to debug.
the cmake install() looks at the CMAKE_BUILD_TYPE for deduce the src dir, but in our case the debug build was created under relesae.