### PR TITLE
Y from cc

### DIFF
--- a/ae_params/ae_params.cpp
+++ b/ae_params/ae_params.cpp
@@ -88,7 +88,12 @@ template<> struct convert<ae_params_t> {
             range_index += 1;
         }
 
-        rhs.cur_y_from_cc_pixels = node["cur_y_from_cc_pixels"].as<uint8_t>();
+        if (node["cur_y_from_cc_pixels"]) {
+            rhs.cur_y_from_cc_pixels = node["cur_y_from_cc_pixels"].as<uint8_t>();
+        }
+        else {
+            rhs.cur_y_from_cc_pixels = 0;
+        }
         
         return ret;
     } //struct convert<ae_params_t>
@@ -100,6 +105,7 @@ std::string ae_params_get_path() {
     const char *path1 = std::getenv("AE_PARAMS_PATH");
     std::string path2 = "./ae_params.yaml";
     std::string path3 = "/home/root/app/imx728/dcc_3856x2176/ae_params.yaml";
+    std::string path4 = "/home/root/autobrains/imx728/dcc_3856x2176/ae_params.yaml";
 
     if (path1!=NULL and fs::exists(path1)) {
         return path1;
@@ -112,6 +118,10 @@ std::string ae_params_get_path() {
     if (fs::exists(path3)) {
         return path3;
     }
+
+    if (fs::exists(path4)) {
+        return path4;
+    }    
 
     return "";
 }

--- a/ae_params/ae_params.cpp
+++ b/ae_params/ae_params.cpp
@@ -42,52 +42,56 @@ template<> struct convert<IssAeRange> {
 };
 
 
-// Specialize YAML::convert for IssAeDynamicParams
-template<> struct convert<IssAeDynamicParams> {
-    static Node encode(const IssAeDynamicParams& rhs) {
+// Specialize YAML::convert for ae_params_t
+template<> struct convert<ae_params_t> {
+    static Node encode(const ae_params_t& rhs) {
         Node node;
 
-        node["targetBrightnessRange"] = rhs.targetBrightnessRange;
-        node["targetBrightness"] = rhs.targetBrightness;
-        node["threshold"] = rhs.threshold;
-        node["enableBlc"] = rhs.enableBlc;  
-        node["exposureTimeStepSize"] = rhs.exposureTimeStepSize;
+        node["targetBrightnessRange"] = rhs.dyn_params.targetBrightnessRange;
+        node["targetBrightness"] = rhs.dyn_params.targetBrightness;
+        node["threshold"] = rhs.dyn_params.threshold;
+        node["enableBlc"] = rhs.dyn_params.enableBlc;  
+        node["exposureTimeStepSize"] = rhs.dyn_params.exposureTimeStepSize;
 
-        for (uint32_t i=0; i<rhs.numAeDynParams; i+=1) {
-            node["ranges"][i]["exposureTimeRange"] = rhs.exposureTimeRange[i];
-            node["ranges"][i]["analogGainRange"] = rhs.analogGainRange[i];
-            node["ranges"][i]["digitalGainRange"] = rhs.digitalGainRange[i];
+        for (uint32_t i=0; i<rhs.dyn_params.numAeDynParams; i+=1) {
+            node["ranges"][i]["exposureTimeRange"] = rhs.dyn_params.exposureTimeRange[i];
+            node["ranges"][i]["analogGainRange"] = rhs.dyn_params.analogGainRange[i];
+            node["ranges"][i]["digitalGainRange"] = rhs.dyn_params.digitalGainRange[i];
         }
+
+        node["cur_y_from_cc_pixels"] = rhs.cur_y_from_cc_pixels;
         
         return node;
     }
 
-    static bool decode(const Node& node, IssAeDynamicParams& rhs) {
+    static bool decode(const Node& node, ae_params_t& rhs) {
         bool ret = true;
 
         if(!node.IsMap()) {
             return false;
         }
 
-        rhs.targetBrightnessRange = node["targetBrightnessRange"].as<IssAeRange>();
-        rhs.targetBrightness = node["targetBrightness"].as<uint32_t>();
-        rhs.threshold = node["threshold"].as<uint32_t>();
-        rhs.enableBlc = node["enableBlc"].as<uint32_t>();
-        rhs.exposureTimeStepSize = node["exposureTimeStepSize"].as<uint32_t>();         
+        rhs.dyn_params.targetBrightnessRange = node["targetBrightnessRange"].as<IssAeRange>();
+        rhs.dyn_params.targetBrightness = node["targetBrightness"].as<uint32_t>();
+        rhs.dyn_params.threshold = node["threshold"].as<uint32_t>();
+        rhs.dyn_params.enableBlc = node["enableBlc"].as<uint32_t>();
+        rhs.dyn_params.exposureTimeStepSize = node["exposureTimeStepSize"].as<uint32_t>();         
 
-        rhs.numAeDynParams = node["ranges"].size();
+        rhs.dyn_params.numAeDynParams = node["ranges"].size();
         int range_index = 0;
 
         for (const auto& range_node : node["ranges"]) {     
-            rhs.exposureTimeRange[range_index] = range_node["exposureTimeRange"].as<IssAeRange>();
-            rhs.analogGainRange[range_index] = range_node["analogGainRange"].as<IssAeRange>();
-            rhs.digitalGainRange[range_index] = range_node["digitalGainRange"].as<IssAeRange>();
+            rhs.dyn_params.exposureTimeRange[range_index] = range_node["exposureTimeRange"].as<IssAeRange>();
+            rhs.dyn_params.analogGainRange[range_index] = range_node["analogGainRange"].as<IssAeRange>();
+            rhs.dyn_params.digitalGainRange[range_index] = range_node["digitalGainRange"].as<IssAeRange>();
             
             range_index += 1;
         }
+
+        rhs.cur_y_from_cc_pixels = node["cur_y_from_cc_pixels"].as<uint8_t>();
         
         return ret;
-    } //struct convert<IssAeDynamicParams>
+    } //struct convert<ae_params_t>
 };
 
 } //namespace YAML
@@ -112,11 +116,11 @@ std::string ae_params_get_path() {
     return "";
 }
 
-int ae_params_get_params_from_yaml(const char *path, IssAeDynamicParams *p_params)
+int ae_params_get_params_from_yaml(const char *path, ae_params_t *p_params)
 {
     try {
         YAML::Node config = YAML::LoadFile(path);
-        *p_params = config.as<IssAeDynamicParams>();
+        *p_params = config.as<ae_params_t>();
     }
     catch (const std::runtime_error& e) {
         LOG(ERROR) << "ae_params_get_params_from_yaml " << e.what() << std::endl;
@@ -126,10 +130,10 @@ int ae_params_get_params_from_yaml(const char *path, IssAeDynamicParams *p_param
     return 1;
 }
 
-int ae_params_get(IssAeDynamicParams *p_params)
+int ae_params_get(ae_params_t *p_params)
 {
     int ret = 0;
-    memset(p_params, 0, sizeof(IssAeDynamicParams));
+    memset(p_params, 0, sizeof(ae_params_t));
 
     std::string path = ae_params_get_path();
     if (path=="") {
@@ -141,7 +145,7 @@ int ae_params_get(IssAeDynamicParams *p_params)
 
     ret = ae_params_get_params_from_yaml(path.c_str(), p_params);
     if (ret==0) {
-        memset(p_params, 0, sizeof(IssAeDynamicParams));
+        memset(p_params, 0, sizeof(ae_params_t));
         return 0;
     }
 
@@ -152,24 +156,26 @@ int ae_params_get(IssAeDynamicParams *p_params)
     return 1;
 }
 
-void ae_params_dump(IssAeDynamicParams *p_ae_dynPrms)
+void ae_params_dump(ae_params_t *p_params)
 {
-    LOG(INFO) << "targetBrightnessRange.min " << p_ae_dynPrms->targetBrightnessRange.min;
-    LOG(INFO) << "targetBrightnessRange.max " << p_ae_dynPrms->targetBrightnessRange.max;
-    LOG(INFO) << "targetBrightness " << p_ae_dynPrms->targetBrightness;
-    LOG(INFO) << "threshold " << p_ae_dynPrms->threshold;
-    LOG(INFO) << "enableBlc " << p_ae_dynPrms->enableBlc;
-    LOG(INFO) << "exposureTimeStepSize " << p_ae_dynPrms->exposureTimeStepSize;
+    LOG(INFO) << "targetBrightnessRange.min " << p_params->dyn_params.targetBrightnessRange.min;
+    LOG(INFO) << "targetBrightnessRange.max " << p_params->dyn_params.targetBrightnessRange.max;
+    LOG(INFO) << "targetBrightness " << p_params->dyn_params.targetBrightness;
+    LOG(INFO) << "threshold " << p_params->dyn_params.threshold;
+    LOG(INFO) << "enableBlc " << p_params->dyn_params.enableBlc;
+    LOG(INFO) << "exposureTimeStepSize " << p_params->dyn_params.exposureTimeStepSize;
 
-    for (uint32_t i=0; i<p_ae_dynPrms->numAeDynParams; i+=1) {
+    for (uint32_t i=0; i<p_params->dyn_params.numAeDynParams; i+=1) {
         LOG(INFO) << "range index " << i;
-        LOG(INFO) << "\texposureTimeRange.min " << p_ae_dynPrms->exposureTimeRange[i].min;
-        LOG(INFO) << "\texposureTimeRange.max " << p_ae_dynPrms->exposureTimeRange[i].max;
-        LOG(INFO) << "\tanalogGainRange.min " << p_ae_dynPrms->analogGainRange[i].min;
-        LOG(INFO) << "\tanalogGainRange.max " << p_ae_dynPrms->analogGainRange[i].max;
-        LOG(INFO) << "\tdigitalGainRange.min " << p_ae_dynPrms->digitalGainRange[i].min;
-        LOG(INFO) << "\tdigitalGainRange.max " << p_ae_dynPrms->digitalGainRange[i].max;
+        LOG(INFO) << "\texposureTimeRange.min " << p_params->dyn_params.exposureTimeRange[i].min;
+        LOG(INFO) << "\texposureTimeRange.max " << p_params->dyn_params.exposureTimeRange[i].max;
+        LOG(INFO) << "\tanalogGainRange.min " << p_params->dyn_params.analogGainRange[i].min;
+        LOG(INFO) << "\tanalogGainRange.max " << p_params->dyn_params.analogGainRange[i].max;
+        LOG(INFO) << "\tdigitalGainRange.min " << p_params->dyn_params.digitalGainRange[i].min;
+        LOG(INFO) << "\tdigitalGainRange.max " << p_params->dyn_params.digitalGainRange[i].max;
     }
+
+    LOG(INFO) << "\tcur_y_from_cc_pixels " << p_params->cur_y_from_cc_pixels;
 }
 
 bool is_glog_en = false;

--- a/ae_params/ae_params.h
+++ b/ae_params/ae_params.h
@@ -8,9 +8,14 @@
 extern "C" {
 #endif
 
-extern int ae_params_get(IssAeDynamicParams *p_params);
-extern int ae_params_get_params_from_yaml(const char *path, IssAeDynamicParams *p_params);
-extern void ae_params_dump(IssAeDynamicParams *p_ae_dynPrms);
+typedef struct {
+    IssAeDynamicParams dyn_params;
+    int cur_y_from_cc_pixels;
+} ae_params_t;
+
+extern int ae_params_get(ae_params_t *p_params);
+extern int ae_params_get_params_from_yaml(const char *path, ae_params_t *p_params);
+extern void ae_params_dump(ae_params_t *p_params);
 
 #ifdef __cplusplus
 }

--- a/ae_params/ae_params_test.c
+++ b/ae_params/ae_params_test.c
@@ -6,102 +6,102 @@
 
 
 void good_single_range() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml/good_single_range.yaml", &params);   
     assert(ret==1);
 
     ae_params_dump(&params);
     
-    assert(params.targetBrightnessRange.min==1);
-    assert(params.targetBrightnessRange.max==2);
-    assert(params.targetBrightness==3);
-    assert(params.threshold==4);
-    assert(params.enableBlc==5);
-    assert(params.exposureTimeStepSize==6);
+    assert(params.dyn_params.targetBrightnessRange.min==1);
+    assert(params.dyn_params.targetBrightnessRange.max==2);
+    assert(params.dyn_params.targetBrightness==3);
+    assert(params.dyn_params.threshold==4);
+    assert(params.dyn_params.enableBlc==5);
+    assert(params.dyn_params.exposureTimeStepSize==6);
     
     int i=0;
-    assert(params.exposureTimeRange[i].min==7);
-    assert(params.exposureTimeRange[i].max==8);
-    assert(params.analogGainRange[i].min==9);
-    assert(params.analogGainRange[i].max==10);
-    assert(params.digitalGainRange[i].min==11);
-    assert(params.digitalGainRange[i].max==12);
+    assert(params.dyn_params.exposureTimeRange[i].min==7);
+    assert(params.dyn_params.exposureTimeRange[i].max==8);
+    assert(params.dyn_params.analogGainRange[i].min==9);
+    assert(params.dyn_params.analogGainRange[i].max==10);
+    assert(params.dyn_params.digitalGainRange[i].min==11);
+    assert(params.dyn_params.digitalGainRange[i].max==12);
 
-    assert(params.numAeDynParams==1);
+    assert(params.dyn_params.numAeDynParams==1);
 }
 
 void good_multi_range() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml/good_multi_range.yaml", &params);
 
     assert(ret==1);
     
-    assert(params.targetBrightnessRange.min==1);
-    assert(params.targetBrightnessRange.max==2);
-    assert(params.targetBrightness==3);
-    assert(params.threshold==4);
-    assert(params.enableBlc==5);
-    assert(params.exposureTimeStepSize==6);
+    assert(params.dyn_params.targetBrightnessRange.min==1);
+    assert(params.dyn_params.targetBrightnessRange.max==2);
+    assert(params.dyn_params.targetBrightness==3);
+    assert(params.dyn_params.threshold==4);
+    assert(params.dyn_params.enableBlc==5);
+    assert(params.dyn_params.exposureTimeStepSize==6);
 
     int i=0;
-    assert(params.exposureTimeRange[i].min==7);
-    assert(params.exposureTimeRange[i].max==8);
-    assert(params.analogGainRange[i].min==9);
-    assert(params.analogGainRange[i].max==10);
-    assert(params.digitalGainRange[i].min==11);
-    assert(params.digitalGainRange[i].max==12);
+    assert(params.dyn_params.exposureTimeRange[i].min==7);
+    assert(params.dyn_params.exposureTimeRange[i].max==8);
+    assert(params.dyn_params.analogGainRange[i].min==9);
+    assert(params.dyn_params.analogGainRange[i].max==10);
+    assert(params.dyn_params.digitalGainRange[i].min==11);
+    assert(params.dyn_params.digitalGainRange[i].max==12);
 
     i=1;
-    assert(params.exposureTimeRange[i].min==20);
-    assert(params.exposureTimeRange[i].max==21);
-    assert(params.analogGainRange[i].min==22);
-    assert(params.analogGainRange[i].max==23);
-    assert(params.digitalGainRange[i].min==24);
-    assert(params.digitalGainRange[i].max==25);    
+    assert(params.dyn_params.exposureTimeRange[i].min==20);
+    assert(params.dyn_params.exposureTimeRange[i].max==21);
+    assert(params.dyn_params.analogGainRange[i].min==22);
+    assert(params.dyn_params.analogGainRange[i].max==23);
+    assert(params.dyn_params.digitalGainRange[i].min==24);
+    assert(params.dyn_params.digitalGainRange[i].max==25);    
 
-    assert(params.numAeDynParams==2);
+    assert(params.dyn_params.numAeDynParams==2);
 }
 
 void missing_root_attr1() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//missing_root_attr1.yaml", &params);
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 void missing_root_attr2() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//missing_root_attr2.yaml", &params);
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 void missing_range_attr() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//missing_range_attr.yaml", &params);
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 void file_doesnt_exist() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//non_existing.yaml", &params);    
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 void illegal_yaml() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//illegal_yaml.yaml", &params);    
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 void wrong_key_type() {
-    IssAeDynamicParams params;
+    ae_params_t params;
     int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml//wrong_key_type.yaml", &params);    
     assert(ret==0);
-    assert(params.targetBrightnessRange.min==0);
+    assert(params.dyn_params.targetBrightnessRange.min==0);
 }
 
 int main() {

--- a/ae_params/test_yaml/good_multi_range.yaml
+++ b/ae_params/test_yaml/good_multi_range.yaml
@@ -24,4 +24,4 @@ ranges:
     digitalGainRange:
       min: 24
       max: 25      
-
+cur_y_from_cc_pixels: 0

--- a/ae_params/test_yaml/good_single_range.yaml
+++ b/ae_params/test_yaml/good_single_range.yaml
@@ -15,4 +15,4 @@ ranges:
     digitalGainRange:
       min: 11
       max: 12
-
+cur_y_from_cc_pixels: 0

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -105,6 +105,7 @@ include_directories(${PROJECT_SOURCE_DIR}
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/algos/ae/include
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/algos/awb/include
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/algos/dcc/include
+                    ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/algos/ae/include
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/sensor_drv/include
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/ti_2a_wrapper/include
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging/kernels/include

--- a/modules/src/linux_aewb_module.c
+++ b/modules/src/linux_aewb_module.c
@@ -65,6 +65,7 @@
 #include "ti_2a_wrapper.h"
 #include "aewb_logger_sender.h"
 #include "ae_params.h"
+#include "TI_aaa_ae.h"
 
 #include <sys/ioctl.h>
 #include <errno.h>
@@ -608,7 +609,11 @@ void get_imx728_ae_dyn_params (IssAeDynamicParams *p_ae_dynPrms)
 
     p_ae_dynPrms->numAeDynParams = count;
 #else
-    ae_params_get(p_ae_dynPrms);
+    ae_params_t ae_params;
+    ae_params_get(&ae_params);
+    memcpy(p_ae_dynPrms, &ae_params.dyn_params, sizeof(IssAeDynamicParams));
+    TI_AE_set_cur_y_from_cc_pixels(ae_params.cur_y_from_cc_pixels);
+
 #endif
 
 }

--- a/modules/src/tiovx_sensor_module.c
+++ b/modules/src/tiovx_sensor_module.c
@@ -73,7 +73,7 @@ vx_status tiovx_init_sensor_obj(SensorObj *sensorObj, char *objName)
     sensorObj->sensor_dcc_enabled=1;
     sensorObj->sensor_exp_control_enabled=0;
     sensorObj->sensor_gain_control_enabled=0;
-    sensorObj->sensor_wdr_enabled=0;
+    sensorObj->sensor_wdr_enabled=1;
     sensorObj->num_cameras_enabled=1;
     sensorObj->ch_mask=1;
     sensorObj->starting_channel=0;

--- a/modules/src/tiovx_viss_module.c
+++ b/modules/src/tiovx_viss_module.c
@@ -82,7 +82,7 @@ vx_status tiovx_viss_module_configure_params(NodeObj *node)
 
     node_cfg->viss_params.sensor_dcc_id       = node_priv->sensor_obj.sensorParams.dccId;
     node_cfg->viss_params.use_case            = 0;
-    node_cfg->viss_params.fcp[0].ee_mode      = TIVX_VPAC_VISS_EE_MODE_OFF;
+    node_cfg->viss_params.fcp[0].ee_mode      = TIVX_VPAC_VISS_EE_MODE_Y8;
     node_cfg->viss_params.fcp[0].chroma_mode  = TIVX_VPAC_VISS_CHROMA_MODE_420;
 
     if(node_cfg->output_select[0] == TIOVX_VISS_MODULE_OUTPUT_EN)


### PR DESCRIPTION
* switched from using the TI `IssAeDynamicParams` type to using an autobrains `ae_params_t` type
* added a `cur_y_from_cc_pixels` property to `ae_params.yaml`
* added a  `TI_AE_set_cur_y_from_cc_pixels()` call to the TI imaging library to propagate the `cur_y_from_cc_pixels` property value. (should set AE to measure brightness directly based on the clear pixels instead of RCCG->RGB-YUV->Y
* changed the default `sensor_wdr_enabled` to true to enable the GLBCE block (only affects cortica.elf not gst).
* changed the default ee_mode to Y8 to enable edge-enhancement in VISS (only affects cortica.elf not gst).
* added `"/home/root/autobrains/imx728/dcc_3856x2176/ae_params.yaml"` to the ae_params search paths