### PR TITLE
added yaml config to switch between fixed exposure/gain configs for debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.10.0)
 project(edgeai-tiovx-apps)
 
 add_subdirectory(aewb_logger)
+# ae_params not added here, it's built with aewb_logger
+# aewb_debug_mode not added here, it's built with aewb_logger
 add_subdirectory(modules)
 add_subdirectory(tests)
 add_subdirectory(apps)

--- a/ae_params/ae_params.cpp
+++ b/ae_params/ae_params.cpp
@@ -68,7 +68,7 @@ template<> struct convert<ae_params_t> {
             node["periodic_fixed_exposure_gain_switch"]["num_configs"] = rhs.periodic_fixed_exposure_gain_switch.num_configs;
 
             for (uint32_t i=0; i<rhs.periodic_fixed_exposure_gain_switch.num_configs; i+=1) {
-                node["periodic_fixed_exposure_gain_switch"]["configs"][i]["exposure_msec"] = rhs.periodic_fixed_exposure_gain_switch.configs[i].exposure_msec;
+                node["periodic_fixed_exposure_gain_switch"]["configs"][i]["exposure_usec"] = rhs.periodic_fixed_exposure_gain_switch.configs[i].exposure_usec;
                 node["periodic_fixed_exposure_gain_switch"]["configs"][i]["analog_gain"] = rhs.periodic_fixed_exposure_gain_switch.configs[i].analog_gain;
             }   
         }
@@ -115,7 +115,7 @@ template<> struct convert<ae_params_t> {
             rhs.periodic_fixed_exposure_gain_switch.num_configs = node["periodic_fixed_exposure_gain_switch"]["num_configs"].as<uint32_t>();
 
             for (uint32_t i=0; i<rhs.periodic_fixed_exposure_gain_switch.num_configs; i+=1) {
-                rhs.periodic_fixed_exposure_gain_switch.configs[i].exposure_msec = node["periodic_fixed_exposure_gain_switch"]["configs"][i]["exposure_msec"].as<uint32_t>();
+                rhs.periodic_fixed_exposure_gain_switch.configs[i].exposure_usec = node["periodic_fixed_exposure_gain_switch"]["configs"][i]["exposure_usec"].as<uint32_t>();
                 rhs.periodic_fixed_exposure_gain_switch.configs[i].analog_gain = node["periodic_fixed_exposure_gain_switch"]["configs"][i]["analog_gain"].as<uint32_t>();
             }   
         }   
@@ -220,7 +220,7 @@ void ae_params_dump(ae_params_t *p_params)
         LOG(INFO) << "periodic_fixed_exposure_gain_switch.num_configs " << p_params->periodic_fixed_exposure_gain_switch.num_configs;
 
         for (uint32_t i=0; i<p_params->periodic_fixed_exposure_gain_switch.num_configs; i+=1) {
-            LOG(INFO) << "periodic_fixed_exposure_gain_switch.configs[" << i << "].exposure_msec " << p_params->periodic_fixed_exposure_gain_switch.configs[i].exposure_msec;
+            LOG(INFO) << "periodic_fixed_exposure_gain_switch.configs[" << i << "].exposure_usec " << p_params->periodic_fixed_exposure_gain_switch.configs[i].exposure_usec;
             LOG(INFO) << "periodic_fixed_exposure_gain_switch.configs[" << i << "].analog_gain " << p_params->periodic_fixed_exposure_gain_switch.configs[i].analog_gain;
         }   
     }

--- a/ae_params/ae_params.h
+++ b/ae_params/ae_params.h
@@ -9,8 +9,21 @@ extern "C" {
 #endif
 
 typedef struct {
+    uint32_t exposure_msec;
+    uint32_t analog_gain; // 1024 = x1
+} fixed_exposure_gain_config_t;
+
+typedef struct {
+    uint8_t enable;
+    uint32_t num_frames_per_config;
+    uint32_t num_configs;
+    fixed_exposure_gain_config_t configs[20];
+} periodic_fixed_exposure_gain_switch_config_t;
+
+typedef struct {
     IssAeDynamicParams dyn_params;
     int cur_y_from_cc_pixels;
+    periodic_fixed_exposure_gain_switch_config_t periodic_fixed_exposure_gain_switch;
 } ae_params_t;
 
 extern int ae_params_get(ae_params_t *p_params);

--- a/ae_params/ae_params.h
+++ b/ae_params/ae_params.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 typedef struct {
-    uint32_t exposure_msec;
+    uint32_t exposure_usec;
     uint32_t analog_gain; // 1024 = x1
 } fixed_exposure_gain_config_t;
 

--- a/ae_params/ae_params_test.c
+++ b/ae_params/ae_params_test.c
@@ -28,6 +28,7 @@ void good_single_range() {
     assert(params.dyn_params.digitalGainRange[i].max==12);
 
     assert(params.dyn_params.numAeDynParams==1);
+    assert(params.periodic_fixed_exposure_gain_switch.enable==0);
 }
 
 void good_multi_range() {
@@ -60,6 +61,54 @@ void good_multi_range() {
     assert(params.dyn_params.digitalGainRange[i].max==25);    
 
     assert(params.dyn_params.numAeDynParams==2);
+    assert(params.periodic_fixed_exposure_gain_switch.enable==0);
+}
+
+void good_periodic_fixed_exposure_gain_switch() {
+    ae_params_t params;
+    int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml/good_periodic_fixed_exposure_gain_switch.yaml", &params);   
+    assert(ret==1);
+
+    ae_params_dump(&params);
+    
+    assert(params.dyn_params.targetBrightnessRange.min==1);
+    assert(params.dyn_params.targetBrightnessRange.max==2);
+    assert(params.dyn_params.targetBrightness==3);
+    assert(params.dyn_params.threshold==4);
+    assert(params.dyn_params.enableBlc==5);
+    assert(params.dyn_params.exposureTimeStepSize==6);
+    
+    int i=0;
+    assert(params.dyn_params.exposureTimeRange[i].min==7);
+    assert(params.dyn_params.exposureTimeRange[i].max==8);
+    assert(params.dyn_params.analogGainRange[i].min==9);
+    assert(params.dyn_params.analogGainRange[i].max==10);
+    assert(params.dyn_params.digitalGainRange[i].min==11);
+    assert(params.dyn_params.digitalGainRange[i].max==12);
+
+    assert(params.dyn_params.numAeDynParams==1);
+
+    assert(params.periodic_fixed_exposure_gain_switch.enable==1);    
+    assert(params.periodic_fixed_exposure_gain_switch.num_frames_per_config==17);
+    assert(params.periodic_fixed_exposure_gain_switch.num_configs==2);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[0].exposure_msec==111);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[0].analog_gain==112);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[1].exposure_msec==113);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[1].analog_gain==114);
+}
+
+void bad_periodic_fixed_exposure_gain_switch_missing_num_configs()
+{
+    ae_params_t params;
+    int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_num_configs.yaml", &params);   
+    assert(ret==0);
+}
+
+void bad_periodic_fixed_exposure_gain_switch_missing_configs()
+{
+    ae_params_t params;
+    int ret = ae_params_get_params_from_yaml("./ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_configs.yaml", &params);   
+    assert(ret==0);
 }
 
 void missing_root_attr1() {
@@ -110,6 +159,15 @@ int main() {
 
     printf("\ngood_multi_range\n");
     good_multi_range();
+
+    printf("\ngood_periodic_fixed_exposure_gain_switch\n");
+    good_periodic_fixed_exposure_gain_switch();
+
+    printf("\nbad_periodic_fixed_exposure_gain_switch_missing_num_configs\n");
+    bad_periodic_fixed_exposure_gain_switch_missing_num_configs();
+
+    printf("\nbad_periodic_fixed_exposure_gain_switch_missing_configs\n");
+    bad_periodic_fixed_exposure_gain_switch_missing_configs();    
 
     printf("\nmissing_root_attr1\n");
     missing_root_attr1();

--- a/ae_params/ae_params_test.c
+++ b/ae_params/ae_params_test.c
@@ -91,9 +91,9 @@ void good_periodic_fixed_exposure_gain_switch() {
     assert(params.periodic_fixed_exposure_gain_switch.enable==1);    
     assert(params.periodic_fixed_exposure_gain_switch.num_frames_per_config==17);
     assert(params.periodic_fixed_exposure_gain_switch.num_configs==2);
-    assert(params.periodic_fixed_exposure_gain_switch.configs[0].exposure_msec==111);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[0].exposure_usec==111);
     assert(params.periodic_fixed_exposure_gain_switch.configs[0].analog_gain==112);
-    assert(params.periodic_fixed_exposure_gain_switch.configs[1].exposure_msec==113);
+    assert(params.periodic_fixed_exposure_gain_switch.configs[1].exposure_usec==113);
     assert(params.periodic_fixed_exposure_gain_switch.configs[1].analog_gain==114);
 }
 

--- a/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_configs.yaml
+++ b/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_configs.yaml
@@ -1,0 +1,22 @@
+targetBrightnessRange:
+  min: 1
+  max: 2
+targetBrightness: 3
+threshold: 4
+enableBlc: 5
+exposureTimeStepSize: 6
+ranges:
+  - exposureTimeRange:
+      min: 7
+      max: 8
+    analogGainRange:
+      min: 9
+      max: 10
+    digitalGainRange:
+      min: 11
+      max: 12
+cur_y_from_cc_pixels: 0
+periodic_fixed_exposure_gain_switch:
+  enable: true
+  num_frames_per_config: 17
+  num_configs: 2

--- a/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_num_configs.yaml
+++ b/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_num_configs.yaml
@@ -1,0 +1,26 @@
+targetBrightnessRange:
+  min: 1
+  max: 2
+targetBrightness: 3
+threshold: 4
+enableBlc: 5
+exposureTimeStepSize: 6
+ranges:
+  - exposureTimeRange:
+      min: 7
+      max: 8
+    analogGainRange:
+      min: 9
+      max: 10
+    digitalGainRange:
+      min: 11
+      max: 12
+cur_y_from_cc_pixels: 0
+periodic_fixed_exposure_gain_switch:
+  enable: true
+  num_frames_per_config: 17
+  configs:
+    - exposure_msec: 111
+      analog_gain: 112
+    - exposure_msec: 113
+      analog_gain: 114

--- a/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_num_configs.yaml
+++ b/ae_params/test_yaml/bad_periodic_fixed_exposure_gain_switch_missing_num_configs.yaml
@@ -20,7 +20,7 @@ periodic_fixed_exposure_gain_switch:
   enable: true
   num_frames_per_config: 17
   configs:
-    - exposure_msec: 111
+    - exposure_usec: 111
       analog_gain: 112
-    - exposure_msec: 113
+    - exposure_usec: 113
       analog_gain: 114

--- a/ae_params/test_yaml/good_periodic_fixed_exposure_gain_switch.yaml
+++ b/ae_params/test_yaml/good_periodic_fixed_exposure_gain_switch.yaml
@@ -21,7 +21,7 @@ periodic_fixed_exposure_gain_switch:
   num_frames_per_config: 17
   num_configs: 2
   configs:
-    - exposure_msec: 111
+    - exposure_usec: 111
       analog_gain: 112
-    - exposure_msec: 113
+    - exposure_usec: 113
       analog_gain: 114

--- a/ae_params/test_yaml/good_periodic_fixed_exposure_gain_switch.yaml
+++ b/ae_params/test_yaml/good_periodic_fixed_exposure_gain_switch.yaml
@@ -1,0 +1,27 @@
+targetBrightnessRange:
+  min: 1
+  max: 2
+targetBrightness: 3
+threshold: 4
+enableBlc: 5
+exposureTimeStepSize: 6
+ranges:
+  - exposureTimeRange:
+      min: 7
+      max: 8
+    analogGainRange:
+      min: 9
+      max: 10
+    digitalGainRange:
+      min: 11
+      max: 12
+cur_y_from_cc_pixels: 0
+periodic_fixed_exposure_gain_switch:
+  enable: true
+  num_frames_per_config: 17
+  num_configs: 2
+  configs:
+    - exposure_msec: 111
+      analog_gain: 112
+    - exposure_msec: 113
+      analog_gain: 114

--- a/aewb_debug_mode/periodic_fixed_exposure_gain_switch.c
+++ b/aewb_debug_mode/periodic_fixed_exposure_gain_switch.c
@@ -1,0 +1,43 @@
+#include "periodic_fixed_exposure_gain_switch.h"
+
+typedef struct {
+    periodic_fixed_exposure_gain_switch_config_t config;
+    uint32_t frame_counter;
+    uint32_t config_index;
+
+} state_t;
+
+static state_t state;
+
+
+void periodic_fixed_exposure_gain_switch_init()
+{
+    state.config_index = 0;
+    state.frame_counter = 0;
+}
+
+void periodic_fixed_exposure_gain_switch_set_config(periodic_fixed_exposure_gain_switch_config_t *config)
+{
+    memcpy(&state.config, config, sizeof(periodic_fixed_exposure_gain_switch_config_t));
+}
+
+void periodic_fixed_exposure_gain_switch_run_if_en(sensor_config_set *sensor_out_data, tivx_ae_awb_params_t *aewb_ptr)
+{
+    if (state.config.enable==0)
+        return;
+
+    sensor_out_data->aePrms.exposureTime[0] = state.config.configs[state.config_index].exposure_msec;
+    sensor_out_data->aePrms.analogGain[0] = state.config.configs[state.config_index].analog_gain;
+    aewb_ptr->exposure_time = sensor_out_data->aePrms.exposureTime[0];
+    aewb_ptr->analog_gain = sensor_out_data->aePrms.analogGain[0];        
+
+    if (state.frame_counter>=state.config.num_frames_per_config-1)
+    {
+        state.frame_counter = 0;
+        state.config_index = (state.config_index+1)%state.config.num_configs;
+    }
+    else
+    {
+        state.frame_counter += 1;
+    }
+}

--- a/aewb_debug_mode/periodic_fixed_exposure_gain_switch.c
+++ b/aewb_debug_mode/periodic_fixed_exposure_gain_switch.c
@@ -26,7 +26,7 @@ void periodic_fixed_exposure_gain_switch_run_if_en(sensor_config_set *sensor_out
     if (state.config.enable==0)
         return;
 
-    sensor_out_data->aePrms.exposureTime[0] = state.config.configs[state.config_index].exposure_msec;
+    sensor_out_data->aePrms.exposureTime[0] = state.config.configs[state.config_index].exposure_usec;
     sensor_out_data->aePrms.analogGain[0] = state.config.configs[state.config_index].analog_gain;
     aewb_ptr->exposure_time = sensor_out_data->aePrms.exposureTime[0];
     aewb_ptr->analog_gain = sensor_out_data->aePrms.analogGain[0];        

--- a/aewb_debug_mode/periodic_fixed_exposure_gain_switch.h
+++ b/aewb_debug_mode/periodic_fixed_exposure_gain_switch.h
@@ -1,0 +1,13 @@
+#ifndef _PERIODIC_FIXED_EXPOSURE_GAIN_SWITCH_
+#define _PERIODIC_FIXED_EXPOSURE_GAIN_SWITCH_
+
+
+#include "linux_aewb_module.h"
+#include "ti_2a_wrapper.h"
+#include "ae_params.h"
+
+void periodic_fixed_exposure_gain_switch_init();
+void periodic_fixed_exposure_gain_switch_set_config(periodic_fixed_exposure_gain_switch_config_t *config);
+void periodic_fixed_exposure_gain_switch_run_if_en(sensor_config_set *sensor_out_data, tivx_ae_awb_params_t *aewb_ptr);
+
+#endif //_PERIODIC_FIXED_EXPOSURE_GAIN_SWITCH_

--- a/aewb_logger/CMakeLists.txt
+++ b/aewb_logger/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     aewb_logger_receiver.c
     aewb_debug_utils.c
     ../ae_params/ae_params.cpp # we add this here to avoid passing an extra lib to Cartica-Renesas
+    ../aewb_debug_mode/periodic_fixed_exposure_gain_switch.c # we add this here to avoid passing an extra lib to Cartica-Renesas
     )
 
 

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -99,6 +99,7 @@ include_directories(${PROJECT_SOURCE_DIR}
                     ${PROJECT_SOURCE_DIR}/utils/include
                     ${PROJECT_SOURCE_DIR}/aewb_logger/
                     ${PROJECT_SOURCE_DIR}/ae_params/
+                    ${PROJECT_SOURCE_DIR}/aewb_debug_mode/
                     ${PSDK_INCLUDE_PATH}/processor_sdk/ivision
                     ${PSDK_INCLUDE_PATH}/processor_sdk/imaging
                     ${PSDK_INCLUDE_PATH}/processor_sdk/ti-perception-toolkit/include


### PR DESCRIPTION
this functionality was added for testing/data collection.
when adding this section to `/home/root/app/imx728/dcc_3856x2176/ae_params.yaml`
if enable is true, we'll still run AWB, but AE results will be overwritten by fixed exposure/gain.
in the example below even frames will run with 8msec/x180, odd frames with 12ms/x200
```
periodic_fixed_exposure_gain_switch:
  enable: true
  num_frames_per_config: 1
  num_configs: 2
  configs:
    - exposure_usec: 8000
      analog_gain: 180000
    - exposure_usec: 12000
      analog_gain: 200000`
```      
