### PR TITLE
changes to allow building edgeai-gst-plugins 

### DIFF
--- a/aewb_debug_mode/periodic_fixed_exposure_gain_switch.h
+++ b/aewb_debug_mode/periodic_fixed_exposure_gain_switch.h
@@ -2,7 +2,6 @@
 #define _PERIODIC_FIXED_EXPOSURE_GAIN_SWITCH_
 
 
-#include "linux_aewb_module.h"
 #include "ti_2a_wrapper.h"
 #include "ae_params.h"
 

--- a/aewb_logger/CMakeLists.txt
+++ b/aewb_logger/CMakeLists.txt
@@ -19,8 +19,11 @@ build_lib(aewb_logger      # Named argument: library name
 
 set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
 
-set(AE_PARAMs_HEADERS ../ae_params/ae_params.h)
-install(FILES ${AE_PARAMs_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/ae_params)
+set(AE_PARAMS_HEADERS ../ae_params/ae_params.h)
+install(FILES ${AE_PARAMS_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/ae_params)
+
+set(AEWB_DEBUG_MODE_HEADERS ../aewb_debug_mode/periodic_fixed_exposure_gain_switch.h)
+install(FILES ${AEWB_DEBUG_MODE_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/aewb_debug_mode)
 
 FILE(GLOB AEWB_LOG_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 install(FILES ${AEWB_LOG_HDRS} DESTINATION ${INCLUDE_INSTALL_DIR}/aewb_logger)


### PR DESCRIPTION
edgeai-gst-plugins references aewb_logger/ae_params/aewb_debug_mode
some cleanup was required for includes to work.